### PR TITLE
Add session scheduling and conflict detection

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -43,6 +43,8 @@ public class Messages {
                 .append(person.getEmail())
                 .append("; Address: ")
                 .append(person.getAddress())
+                .append("; Session: ")
+                .append(person.getSession())
                 .append("; Tags: ");
         person.getTags().forEach(builder::append);
         return builder.toString();

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -12,6 +12,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_HEIGHT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PAID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SESSION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_WEIGHT;
 
@@ -40,6 +41,7 @@ public class AddCommand extends Command {
             + PREFIX_GENDER + "GENDER "
             + PREFIX_DEADLINE + "DEADLINE(yyyy-MM-dd) "
             + PREFIX_PAID + "PAID "
+            + PREFIX_SESSION + "SESSION "
             + PREFIX_BODYFAT + "BODYFAT "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
@@ -54,12 +56,15 @@ public class AddCommand extends Command {
             + PREFIX_GENDER + "male "
             + PREFIX_DEADLINE + "2025-11-10 "
             + PREFIX_PAID + "false "
+            + PREFIX_SESSION + "WEEKLY:MON 18:00 "
             + PREFIX_BODYFAT + "18.5 "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_CONFLICTING_SESSION =
+            "This session slot is already booked by another person";
 
     private final Person toAdd;
 
@@ -77,6 +82,10 @@ public class AddCommand extends Command {
 
         if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
+        if (model.hasSessionConflict(toAdd)) {
+            throw new CommandException(MESSAGE_CONFLICTING_SESSION);
         }
 
         model.addPerson(toAdd);

--- a/src/main/java/seedu/address/logic/commands/AgeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AgeCommand.java
@@ -70,6 +70,7 @@ public class AgeCommand extends Command {
                 personToEdit.getDeadline(),
                 personToEdit.getPaymentStatus(),
                 personToEdit.getBodyfat(),
+                personToEdit.getSession(),
                 personToEdit.getTags());
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/commands/BodyfatCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BodyfatCommand.java
@@ -68,6 +68,7 @@ public class BodyfatCommand extends Command {
                 personToEdit.getDeadline(),
                 personToEdit.getPaymentStatus(),
                 bodyfat,
+                personToEdit.getSession(),
                 personToEdit.getTags()
         );
 

--- a/src/main/java/seedu/address/logic/commands/DeadlineCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeadlineCommand.java
@@ -70,6 +70,7 @@ public class DeadlineCommand extends Command {
                 deadline,
                 personToEdit.getPaymentStatus(),
                 personToEdit.getBodyfat(),
+                personToEdit.getSession(),
                 personToEdit.getTags());
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_HEIGHT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PAID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SESSION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_WEIGHT;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
@@ -37,6 +38,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Paid;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Session;
 import seedu.address.model.person.Weight;
 import seedu.address.model.tag.Tag;
 
@@ -59,6 +61,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_HEIGHT + "HEIGHT] "
             + "[" + PREFIX_WEIGHT + "WEIGHT] "
             + "[" + PREFIX_PAID + "PAID] "
+            + "[" + PREFIX_SESSION + "SESSION] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
@@ -100,6 +103,10 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        if (model.hasSessionConflict(editedPerson, personToEdit)) {
+            throw new CommandException(AddCommand.MESSAGE_CONFLICTING_SESSION);
+        }
+
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
@@ -125,9 +132,10 @@ public class EditCommand extends Command {
         Bodyfat updatedBodyfat = editPersonDescriptor.getBodyfat().orElse(personToEdit.getBodyfat());
         Age updatedAge = editPersonDescriptor.getAge().orElse(personToEdit.getAge());
         Gender updatedGender = editPersonDescriptor.getGender().orElse(personToEdit.getGender());
+        Session updatedSession = editPersonDescriptor.getSession().orElse(personToEdit.getSession());
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedGoal,
                 updatedHeight, updatedWeight, updatedAge, updatedGender, updatedDeadline, updatedPaid,
-                updatedBodyfat, updatedTags);
+                updatedBodyfat, updatedSession, updatedTags);
     }
 
     @Override
@@ -169,6 +177,7 @@ public class EditCommand extends Command {
         private Goal goal;
         private Paid paid;
         private Bodyfat bodyfat;
+        private Session session;
         private Set<Tag> tags;
 
         public EditPersonDescriptor() {}
@@ -189,12 +198,13 @@ public class EditCommand extends Command {
             setPaid(toCopy.paid);
             setGoal(toCopy.goal);
             setBodyfat(toCopy.bodyfat);
+            setSession(toCopy.session);
             setTags(toCopy.tags);
         }
 
         public boolean isAnyFieldEdited() {
             return CollectionUtil.isAnyNonNull(name, phone, email, address, height, weight, age, gender,
-                    deadline, tags, paid, bodyfat);
+                    deadline, tags, paid, bodyfat, session);
         }
 
         public void setName(Name name) {
@@ -298,6 +308,14 @@ public class EditCommand extends Command {
             return Optional.ofNullable(paid);
         }
 
+        public void setSession(Session session) {
+            this.session = session;
+        }
+
+        public Optional<Session> getSession() {
+            return Optional.ofNullable(session);
+        }
+
         public void setTags(Set<Tag> tags) {
             this.tags = (tags != null) ? new HashSet<>(tags) : null;
         }
@@ -327,6 +345,7 @@ public class EditCommand extends Command {
                     && Objects.equals(goal, otherEditPersonDescriptor.goal)
                     && Objects.equals(bodyfat, otherEditPersonDescriptor.bodyfat)
                     && Objects.equals(paid, otherEditPersonDescriptor.paid)
+                    && Objects.equals(session, otherEditPersonDescriptor.session)
                     && Objects.equals(tags, otherEditPersonDescriptor.tags);
         }
 
@@ -343,6 +362,7 @@ public class EditCommand extends Command {
                     .add("goal", goal)
                     .add("bodyfat", bodyfat)
                     .add("paid", paid)
+                    .add("session", session)
                     .add("tags", tags)
                     .toString();
         }

--- a/src/main/java/seedu/address/logic/commands/GenderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/GenderCommand.java
@@ -69,6 +69,7 @@ public class GenderCommand extends Command {
                 personToEdit.getDeadline(),
                 personToEdit.getPaymentStatus(),
                 personToEdit.getBodyfat(),
+                personToEdit.getSession(),
                 personToEdit.getTags());
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/commands/GoalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/GoalCommand.java
@@ -69,6 +69,7 @@ public class GoalCommand extends Command {
                 personToEdit.getDeadline(),
                 personToEdit.getPaymentStatus(),
                 personToEdit.getBodyfat(),
+                personToEdit.getSession(),
                 personToEdit.getTags());
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/commands/HeightCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HeightCommand.java
@@ -68,6 +68,7 @@ public class HeightCommand extends Command {
                 personToEdit.getDeadline(),
                 personToEdit.getPaymentStatus(),
                 personToEdit.getBodyfat(),
+                personToEdit.getSession(),
                 personToEdit.getTags());
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/commands/PaidCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PaidCommand.java
@@ -67,6 +67,7 @@ public class PaidCommand extends Command {
                 personToEdit.getDeadline(),
                 paid, // updated paid status
                 personToEdit.getBodyfat(),
+                personToEdit.getSession(),
                 personToEdit.getTags());
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/commands/WeightCommand.java
+++ b/src/main/java/seedu/address/logic/commands/WeightCommand.java
@@ -68,6 +68,7 @@ public class WeightCommand extends Command {
                 personToEdit.getDeadline(),
                 personToEdit.getPaymentStatus(),
                 personToEdit.getBodyfat(),
+                personToEdit.getSession(),
                 personToEdit.getTags());
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -12,6 +12,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_HEIGHT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PAID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SESSION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_WEIGHT;
 
@@ -32,6 +33,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Paid;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Session;
 import seedu.address.model.person.Weight;
 import seedu.address.model.tag.Tag;
 
@@ -49,18 +51,18 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_ADDRESS, PREFIX_TAG, PREFIX_HEIGHT, PREFIX_WEIGHT, PREFIX_AGE, PREFIX_GENDER,
-                        PREFIX_DEADLINE, PREFIX_PAID, PREFIX_BODYFAT);
+                        PREFIX_DEADLINE, PREFIX_PAID, PREFIX_SESSION, PREFIX_BODYFAT);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE,
                 PREFIX_EMAIL, PREFIX_HEIGHT, PREFIX_WEIGHT, PREFIX_AGE, PREFIX_GENDER, PREFIX_DEADLINE,
-                PREFIX_PAID, PREFIX_BODYFAT)
+                PREFIX_PAID, PREFIX_SESSION, PREFIX_BODYFAT)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_ADDRESS, PREFIX_HEIGHT, PREFIX_WEIGHT, PREFIX_AGE, PREFIX_GENDER, PREFIX_DEADLINE,
-                PREFIX_PAID, PREFIX_BODYFAT);
+                PREFIX_PAID, PREFIX_SESSION, PREFIX_BODYFAT);
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
@@ -80,9 +82,10 @@ public class AddCommandParser implements Parser<AddCommand> {
         Age age = ParserUtil.parseAge(argMultimap.getValue(PREFIX_AGE).get());
         Gender gender = ParserUtil.parseGender(argMultimap.getValue(PREFIX_GENDER).get());
         Bodyfat bodyfat = ParserUtil.parseBodyfat(argMultimap.getValue(PREFIX_BODYFAT).get());
+        Session session = ParserUtil.parseSession(argMultimap.getValue(PREFIX_SESSION).get());
 
         Person person = new Person(name, phone, email, address, goal, height, weight, age, gender,
-                deadline, paid, bodyfat, tagList);
+                deadline, paid, bodyfat, session, tagList);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -19,5 +19,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_DEADLINE = new Prefix("dl/");
     public static final Prefix PREFIX_BODYFAT = new Prefix("bf/");
+    public static final Prefix PREFIX_SESSION = new Prefix("s/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -13,6 +13,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_HEIGHT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PAID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SESSION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_WEIGHT;
 
@@ -42,7 +43,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_ADDRESS, PREFIX_DEADLINE, PREFIX_GOAL, PREFIX_HEIGHT, PREFIX_WEIGHT,
-                        PREFIX_AGE, PREFIX_GENDER, PREFIX_PAID, PREFIX_BODYFAT, PREFIX_TAG);
+                        PREFIX_AGE, PREFIX_GENDER, PREFIX_PAID, PREFIX_SESSION, PREFIX_BODYFAT, PREFIX_TAG);
 
         Index index;
 
@@ -54,7 +55,7 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_ADDRESS, PREFIX_DEADLINE, PREFIX_GOAL, PREFIX_HEIGHT, PREFIX_WEIGHT,
-                PREFIX_AGE, PREFIX_GENDER, PREFIX_PAID, PREFIX_BODYFAT);
+                PREFIX_AGE, PREFIX_GENDER, PREFIX_PAID, PREFIX_SESSION, PREFIX_BODYFAT);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
@@ -93,6 +94,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         if (argMultimap.getValue(PREFIX_BODYFAT).isPresent()) {
             editPersonDescriptor.setBodyfat(ParserUtil.parseBodyfat(argMultimap.getValue(PREFIX_BODYFAT).get()));
+        }
+        if (argMultimap.getValue(PREFIX_SESSION).isPresent()) {
+            editPersonDescriptor.setSession(ParserUtil.parseSession(argMultimap.getValue(PREFIX_SESSION).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -21,6 +21,7 @@ import seedu.address.model.person.Height;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Paid;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Session;
 import seedu.address.model.person.Weight;
 import seedu.address.model.tag.Tag;
 
@@ -171,6 +172,22 @@ public class ParserUtil {
     public static Deadline parseDeadline(Optional<String> rawOpt) throws ParseException {
         // If the prefix is missing entirely, treat as empty (no deadline)
         return parseDeadline(rawOpt.orElse(""));
+    }
+
+    /**
+     * Parses a {@code String session} into a {@code Session}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code session} is invalid.
+     */
+    public static Session parseSession(String session) throws ParseException {
+        requireNonNull(session);
+        String trimmedSession = session.trim();
+        try {
+            return Session.fromString(trimmedSession);
+        } catch (IllegalArgumentException ex) {
+            throw new ParseException(ex.getMessage(), ex);
+        }
     }
     /**
      * Parses a {@code String height} into a {@code Height}.

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -68,6 +68,23 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if {@code person}'s session conflicts with another person in the address book.
+     */
+    public boolean hasSessionConflict(Person person) {
+        requireNonNull(person);
+        return persons.hasSessionConflict(person);
+    }
+
+    /**
+     * Returns true if {@code person}'s session conflicts with another person excluding {@code toIgnore}.
+     */
+    public boolean hasSessionConflict(Person person, Person toIgnore) {
+        requireNonNull(person);
+        requireNonNull(toIgnore);
+        return persons.hasSessionConflict(person, toIgnore);
+    }
+
+    /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -58,6 +58,16 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
+     * Returns true if {@code person}'s session conflicts with an existing person in the address book.
+     */
+    boolean hasSessionConflict(Person person);
+
+    /**
+     * Returns true if {@code person}'s session conflicts with an existing person other than {@code toIgnore}.
+     */
+    boolean hasSessionConflict(Person person, Person toIgnore);
+
+    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -94,6 +94,18 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasSessionConflict(Person person) {
+        requireNonNull(person);
+        return addressBook.hasSessionConflict(person);
+    }
+
+    @Override
+    public boolean hasSessionConflict(Person person, Person toIgnore) {
+        requireAllNonNull(person, toIgnore);
+        return addressBook.hasSessionConflict(person, toIgnore);
+    }
+
+    @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -33,14 +33,16 @@ public class Person {
     private final Age age;
     private final Gender gender;
     private final Bodyfat bodyfat;
+    private final Session session;
 
     private final Set<Tag> tags = new HashSet<>();
     /**
      * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address, Goal goal, Height height, Weight weight,
-            Age age, Gender gender, Deadline deadline, Paid paid, Bodyfat bodyfat, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, goal, height, weight, age, gender, paid, bodyfat, tags);
+            Age age, Gender gender, Deadline deadline, Paid paid, Bodyfat bodyfat, Session session, Set<Tag> tags) {
+        requireAllNonNull(name, phone, email, address, goal, height, weight, age, gender, paid, bodyfat, session,
+                tags);
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -54,6 +56,7 @@ public class Person {
         this.tags.addAll(tags);
         this.paid = paid;
         this.bodyfat = bodyfat;
+        this.session = session;
     }
 
     public Name getName() {
@@ -104,6 +107,10 @@ public class Person {
         return bodyfat;
     }
 
+    public Session getSession() {
+        return session;
+    }
+
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
@@ -152,6 +159,7 @@ public class Person {
                 && age.equals(otherPerson.age)
                 && gender.equals(otherPerson.gender)
                 && bodyfat.equals(otherPerson.bodyfat)
+                && session.equals(otherPerson.session)
                 && tags.equals(otherPerson.tags);
     }
 
@@ -159,7 +167,7 @@ public class Person {
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
         return Objects.hash(name, phone, email, address, goal, height, weight, age, gender,
-                deadline, paid, bodyfat, tags);
+                deadline, paid, bodyfat, session, tags);
     }
 
     @Override
@@ -177,6 +185,7 @@ public class Person {
                 .add("gender", gender)
                 .add("paid", paid)
                 .add("bodyfat", bodyfat)
+                .add("session", session)
                 .add("tags", tags)
                 .toString();
     }

--- a/src/main/java/seedu/address/model/person/Session.java
+++ b/src/main/java/seedu/address/model/person/Session.java
@@ -1,0 +1,283 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Clock;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Represents a training session slot for a person.
+ * Guarantees: immutable; is valid as declared in {@link #fromString(String)}
+ */
+public class Session {
+
+    public static final String MESSAGE_CONSTRAINTS_FORMAT = "Error: Session format must be either: "
+            + "YYYY-MM-DD HH:MM OR [WEEKLY|BIWEEKLY|MONTHLY]:[DAY] HH:MM";
+    public static final String MESSAGE_CONSTRAINTS_TIME = "Error: Invalid time. Use 24-hour format (00:00–23:59).";
+    public static final String MESSAGE_CONSTRAINTS_DAY = "Error: Invalid day. Use MON, TUE, etc.";
+    public static final String MESSAGE_CONSTRAINTS_PAST_DATE = "Error: Session date cannot be in the past.";
+
+    private static final Pattern ONE_OFF_PATTERN = Pattern.compile(
+            "^(?<date>\\d{4}-\\d{2}-\\d{2})\\s+(?<time>\\d{2}:\\d{2})$");
+    private static final Pattern RECURRING_PATTERN = Pattern.compile(
+            "^(?<type>WEEKLY|BIWEEKLY|MONTHLY):(?<spec>[^\\s]+)\\s+(?<time>\\d{2}:\\d{2})$",
+            Pattern.CASE_INSENSITIVE);
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm")
+            .withResolverStyle(ResolverStyle.STRICT);
+    private static final int MONTH_LOOKAHEAD = 24; // For conflict checks between monthly and weekly/biweekly sessions
+
+    private final SessionType type;
+    private final LocalDateTime oneOffDateTime;
+    private final DayOfWeek dayOfWeek;
+    private final int dayOfMonth;
+    private final LocalTime time;
+    private final String value;
+
+    private final Clock clock;
+
+    private Session(SessionType type, LocalDateTime oneOffDateTime, DayOfWeek dayOfWeek,
+            int dayOfMonth, LocalTime time, String value, Clock clock) {
+        this.type = type;
+        this.oneOffDateTime = oneOffDateTime;
+        this.dayOfWeek = dayOfWeek;
+        this.dayOfMonth = dayOfMonth;
+        this.time = time;
+        this.value = value;
+        this.clock = clock;
+    }
+
+    /**
+     * Creates a {@code Session} by parsing the provided {@code raw} string.
+     */
+    public static Session fromString(String raw) {
+        return fromString(raw, Clock.systemDefaultZone());
+    }
+
+    /**
+     * Internal factory that allows injecting a {@link Clock} for testing.
+     */
+    static Session fromString(String raw, Clock clock) {
+        requireNonNull(raw);
+        requireNonNull(clock);
+        String trimmed = raw.trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_FORMAT);
+        }
+
+        Matcher oneOffMatcher = ONE_OFF_PATTERN.matcher(trimmed);
+        if (oneOffMatcher.matches()) {
+            LocalDate date = parseDate(oneOffMatcher.group("date"));
+            LocalTime time = parseTime(oneOffMatcher.group("time"));
+            LocalDateTime dateTime = LocalDateTime.of(date, time);
+            if (dateTime.isBefore(LocalDateTime.now(clock))) {
+                throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_PAST_DATE);
+            }
+            String canonical = dateTime.format(DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm"));
+            return new Session(SessionType.ONE_OFF, dateTime, null, -1, time, canonical, clock);
+        }
+
+        Matcher recurringMatcher = RECURRING_PATTERN.matcher(trimmed.toUpperCase(Locale.ROOT));
+        if (recurringMatcher.matches()) {
+            SessionType type = SessionType.fromString(recurringMatcher.group("type"));
+            LocalTime time = parseTime(recurringMatcher.group("time"));
+            switch (type) {
+            case WEEKLY:
+            case BIWEEKLY:
+                DayOfWeek day = parseDayOfWeek(recurringMatcher.group("spec"));
+                String canonicalWeekly = type + ":" + day.name() + " " + formatTime(time);
+                return new Session(type, null, day, -1, time, canonicalWeekly, clock);
+            case MONTHLY:
+                int dayOfMonth = parseDayOfMonth(recurringMatcher.group("spec"));
+                String canonicalMonthly = type + ":" + String.format(Locale.ROOT, "%02d", dayOfMonth)
+                        + " " + formatTime(time);
+                return new Session(type, null, null, dayOfMonth, time, canonicalMonthly, clock);
+            default:
+                throw new IllegalStateException("Unhandled session type: " + type);
+            }
+        }
+
+        throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_FORMAT);
+    }
+
+    /**
+     * Returns true if the given {@code raw} string can be parsed into a {@code Session}.
+     */
+    public static boolean isValidSession(String raw) {
+        try {
+            fromString(raw);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private static LocalDate parseDate(String dateStr) {
+        try {
+            return LocalDate.parse(dateStr, DATE_FORMATTER);
+        } catch (DateTimeParseException ex) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_FORMAT, ex);
+        }
+    }
+
+    private static LocalTime parseTime(String timeStr) {
+        try {
+            return LocalTime.parse(timeStr, TIME_FORMATTER);
+        } catch (DateTimeParseException ex) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_TIME, ex);
+        }
+    }
+
+    private static DayOfWeek parseDayOfWeek(String raw) {
+        try {
+            return DayOfWeek.valueOf(raw.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_DAY, ex);
+        }
+    }
+
+    private static int parseDayOfMonth(String raw) {
+        try {
+            int value = Integer.parseInt(raw);
+            if (value < 1 || value > 31) {
+                throw new NumberFormatException();
+            }
+            return value;
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_FORMAT, ex);
+        }
+    }
+
+    private static String formatTime(LocalTime time) {
+        return time.format(TIME_FORMATTER);
+    }
+
+    public SessionType getType() {
+        return type;
+    }
+
+    public String toStorageString() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, oneOffDateTime, dayOfWeek, dayOfMonth, time);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Session)) {
+            return false;
+        }
+
+        Session otherSession = (Session) other;
+        return type == otherSession.type
+                && Objects.equals(oneOffDateTime, otherSession.oneOffDateTime)
+                && Objects.equals(dayOfWeek, otherSession.dayOfWeek)
+                && dayOfMonth == otherSession.dayOfMonth
+                && Objects.equals(time, otherSession.time);
+    }
+
+    /**
+     * Returns true if this session conflicts with {@code other}.
+     */
+    public boolean conflictsWith(Session other) {
+        requireNonNull(other);
+        if (this.type == SessionType.ONE_OFF) {
+            return other.occursOn(oneOffDateTime);
+        }
+        if (other.type == SessionType.ONE_OFF) {
+            return this.occursOn(other.oneOffDateTime);
+        }
+
+        if (this.type == SessionType.MONTHLY && other.type == SessionType.MONTHLY) {
+            return this.dayOfMonth == other.dayOfMonth && this.time.equals(other.time);
+        }
+
+        if (this.type == SessionType.MONTHLY) {
+            return conflictsMonthlyWithRecurring(this, other);
+        }
+        if (other.type == SessionType.MONTHLY) {
+            return conflictsMonthlyWithRecurring(other, this);
+        }
+
+        // Both weekly or biweekly
+        return this.dayOfWeek == other.dayOfWeek && this.time.equals(other.time);
+    }
+
+    private boolean occursOn(LocalDateTime candidate) {
+        switch (type) {
+        case ONE_OFF:
+            return oneOffDateTime.equals(candidate);
+        case WEEKLY:
+        case BIWEEKLY:
+            return candidate.getDayOfWeek() == dayOfWeek && candidate.toLocalTime().equals(time);
+        case MONTHLY:
+            return candidate.getDayOfMonth() == dayOfMonth && candidate.toLocalTime().equals(time);
+        default:
+            throw new IllegalStateException("Unhandled session type: " + type);
+        }
+    }
+
+    private static boolean conflictsMonthlyWithRecurring(Session monthly, Session recurring) {
+        if (!monthly.time.equals(recurring.time)) {
+            return false;
+        }
+        DayOfWeek recurringDay = recurring.dayOfWeek;
+        if (recurringDay == null) {
+            // Should not happen unless recurring is monthly
+            return false;
+        }
+        YearMonth start = YearMonth.from(LocalDate.now(monthly.clock));
+        for (int i = 0; i < MONTH_LOOKAHEAD; i++) {
+            YearMonth current = start.plusMonths(i);
+            if (monthly.dayOfMonth > current.lengthOfMonth()) {
+                continue;
+            }
+            LocalDate date = current.atDay(monthly.dayOfMonth);
+            if (date.getDayOfWeek() == recurringDay) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Represents the supported session recurrence types.
+     */
+    public enum SessionType {
+        ONE_OFF,
+        WEEKLY,
+        BIWEEKLY,
+        MONTHLY;
+
+        static SessionType fromString(String raw) {
+            try {
+                return valueOf(raw.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_FORMAT, ex);
+            }
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/person/exceptions/ConflictingSessionException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/ConflictingSessionException.java
@@ -1,0 +1,10 @@
+package seedu.address.model.person.exceptions;
+
+/**
+ * Signals that the operation would result in two persons having conflicting session slots.
+ */
+public class ConflictingSessionException extends RuntimeException {
+    public ConflictingSessionException() {
+        super("Operation would result in conflicting session slots");
+    }
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -18,6 +18,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Paid;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Session;
 import seedu.address.model.person.Weight;
 import seedu.address.model.tag.Tag;
 
@@ -37,6 +38,7 @@ public class SampleDataUtil {
                 Deadline.fromString("2025-11-15"),
                 new Paid("false"), // added Paid
                 new Bodyfat("30.0"),
+                Session.fromString("WEEKLY:MON 08:00"),
                 getTagSet("friends")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
@@ -48,6 +50,7 @@ public class SampleDataUtil {
                 Deadline.fromString("2025-11-15"),
                 new Paid("true"),
                 new Bodyfat("30.0"),
+                Session.fromString("WEEKLY:TUE 09:00"),
                 getTagSet("colleagues", "friends")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
@@ -59,6 +62,7 @@ public class SampleDataUtil {
                 Deadline.fromString("2025-11-15"),
                 new Paid("false"),
                 new Bodyfat("30.0"),
+                Session.fromString("WEEKLY:WED 10:00"),
                 getTagSet("neighbours")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
@@ -70,6 +74,7 @@ public class SampleDataUtil {
                 Deadline.fromString("2025-11-15"),
                 new Paid("false"),
                 new Bodyfat("30.0"),
+                Session.fromString("WEEKLY:THU 11:00"),
                 getTagSet("family")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
@@ -81,6 +86,7 @@ public class SampleDataUtil {
                 Deadline.fromString("2025-11-15"),
                 new Paid("true"),
                 new Bodyfat("30.0"),
+                Session.fromString("WEEKLY:FRI 12:00"),
                 getTagSet("classmates")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
@@ -92,6 +98,7 @@ public class SampleDataUtil {
                 Deadline.fromString("2025-11-15"),
                 new Paid("false"),
                 new Bodyfat("30.0"),
+                Session.fromString("WEEKLY:SAT 13:00"),
                 getTagSet("colleagues"))
         };
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -22,6 +22,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Paid;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Session;
 import seedu.address.model.person.Weight;
 import seedu.address.model.tag.Tag;
 
@@ -44,6 +45,7 @@ class JsonAdaptedPerson {
     private final String gender;
     private final String bodyfat;
     private final String paid; // New field for payment status
+    private final String session;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
     /**
@@ -61,6 +63,7 @@ class JsonAdaptedPerson {
                              @JsonProperty("gender") String gender,
                              @JsonProperty("deadline") String deadline,
                              @JsonProperty("paid") String paid,
+                             @JsonProperty("session") String session,
                              @JsonProperty("bodyfat") String bodyfat,
                              @JsonProperty("tags") List<JsonAdaptedTag> tags) {
         this.name = name;
@@ -74,6 +77,7 @@ class JsonAdaptedPerson {
         this.age = age;
         this.gender = gender;
         this.paid = paid;
+        this.session = session;
         this.bodyfat = bodyfat;
         if (tags != null) {
             this.tags.addAll(tags);
@@ -95,6 +99,7 @@ class JsonAdaptedPerson {
         age = String.valueOf(source.getAge().value); // convert int → String
         gender = source.getGender().value; // convert Gender to String
         paid = source.getPaymentStatus().toString(); // Convert Paid to String
+        session = source.getSession().toStorageString();
         bodyfat = source.getBodyfat().toString();
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
@@ -206,10 +211,21 @@ class JsonAdaptedPerson {
         }
         final Bodyfat modelBodyfat = new Bodyfat(bodyfat);
 
+        if (session == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Session.class.getSimpleName()));
+        }
+        final Session modelSession;
+        try {
+            modelSession = Session.fromString(session);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalValueException(ex.getMessage(), ex);
+        }
+
         final Set<Tag> modelTags = new HashSet<>(personTags);
 
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelGoal,
-                modelHeight, modelWeight, modelAge, modelGender, modelDeadline, modelPaid, modelBodyfat, modelTags);
+                modelHeight, modelWeight, modelAge, modelGender, modelDeadline, modelPaid, modelBodyfat,
+                modelSession, modelTags);
     }
 
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -55,6 +55,8 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label paid;
     @FXML
+    private Label session;
+    @FXML
     private FlowPane tags;
 
     /**
@@ -76,6 +78,7 @@ public class PersonCard extends UiPart<Region> {
         goal.setText("Personal Goal: " + person.getGoal().value);
         bodyfat.setText("Bodyfat Percentage: " + person.getBodyfat().toString() + "%");
         paid.setText("Payment Status: " + (person.getPaymentStatus().value ? "Paid" : "Not Paid"));
+        session.setText("Session: " + person.getSession().toStorageString());
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -58,6 +58,7 @@
       </Separator>
       <Label styleClass="cell_medium_label" text="Payment Details: " />
       <Label fx:id="paid" styleClass="cell_small_label" text="\$paid" />
+      <Label fx:id="session" styleClass="cell_small_label" text="\$session" />
       <Label fx:id="deadline" styleClass="cell_small_label" text="\$deadline" />
     </VBox>
   </GridPane>

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -13,6 +13,7 @@ import static seedu.address.logic.commands.CommandTestUtil.HEIGHT_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PAID_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.SESSION_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.WEIGHT_DESC_AMY;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.AMY;
@@ -174,9 +175,9 @@ public class LogicManagerTest {
         // Triggers the saveAddressBook method by executing an add command
         String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
                 + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + HEIGHT_DESC_AMY + WEIGHT_DESC_AMY + AGE_DESC_AMY
-                + GENDER_DESC_AMY + DEADLINE_DESC_AMY + PAID_DESC_AMY + BODYFAT_DESC_AMY;
+                + GENDER_DESC_AMY + DEADLINE_DESC_AMY + PAID_DESC_AMY + BODYFAT_DESC_AMY + SESSION_DESC_AMY;
         Person expectedPerson = new PersonBuilder(AMY).withGoal("").withPaid("false")
-                .withWeight("60").withBodyfat("18.5").withTags().build();
+                .withWeight("60").withBodyfat("18.5").withSession("WEEKLY:MON 18:00").withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addPerson(expectedPerson);
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -12,6 +12,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_HEIGHT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PAID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SESSION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_WEIGHT;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -58,6 +59,8 @@ public class CommandTestUtil {
     public static final String VALID_PAID_BOB = "false";
     public static final String VALID_BODYFAT_AMY = "18.5";
     public static final String VALID_BODYFAT_BOB = "20.0";
+    public static final String VALID_SESSION_AMY = "WEEKLY:MON 18:00";
+    public static final String VALID_SESSION_BOB = "WEEKLY:TUE 19:00";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
@@ -83,6 +86,8 @@ public class CommandTestUtil {
     public static final String PAID_DESC_BOB = " " + PREFIX_PAID + VALID_PAID_BOB;
     public static final String BODYFAT_DESC_AMY = " " + PREFIX_BODYFAT + VALID_BODYFAT_AMY;
     public static final String BODYFAT_DESC_BOB = " " + PREFIX_BODYFAT + VALID_BODYFAT_BOB;
+    public static final String SESSION_DESC_AMY = " " + PREFIX_SESSION + VALID_SESSION_AMY;
+    public static final String SESSION_DESC_BOB = " " + PREFIX_SESSION + VALID_SESSION_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
@@ -91,6 +96,7 @@ public class CommandTestUtil {
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_SESSION_DESC = " " + PREFIX_SESSION + "2025/01/01 25:00";
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
@@ -101,10 +107,10 @@ public class CommandTestUtil {
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withTags(VALID_TAG_FRIEND).build();
+                .withTags(VALID_TAG_FRIEND).withSession(VALID_SESSION_AMY).build();
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withSession(VALID_SESSION_BOB).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -20,6 +20,7 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_SESSION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PAID_DESC_AMY;
@@ -28,6 +29,8 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.SESSION_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.SESSION_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
@@ -35,6 +38,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_BODYFAT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SESSION_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_WEIGHT_BOB;
@@ -65,6 +69,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Session;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
@@ -75,23 +80,25 @@ public class AddCommandParserTest {
     public void parse_allFieldsPresent_success() {
         Person expectedPerson = new PersonBuilder(BOB).withGoal("").withPaid("false")
                 .withWeight(VALID_WEIGHT_BOB).withBodyfat(VALID_BODYFAT_BOB)
+                .withSession(VALID_SESSION_BOB)
                 .withTags(VALID_TAG_FRIEND).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + HEIGHT_DESC_BOB + WEIGHT_DESC_BOB + AGE_DESC_BOB + GENDER_DESC_BOB
-                + DEADLINE_DESC_BOB + PAID_DESC_BOB + BODYFAT_DESC_BOB + TAG_DESC_FRIEND,
+                + DEADLINE_DESC_BOB + PAID_DESC_BOB + BODYFAT_DESC_BOB + SESSION_DESC_BOB + TAG_DESC_FRIEND,
                 new AddCommand(expectedPerson));
 
 
         // multiple tags - all accepted
         Person expectedPersonMultipleTags = new PersonBuilder(BOB).withGoal("").withPaid("false")
                 .withWeight(VALID_WEIGHT_BOB).withBodyfat(VALID_BODYFAT_BOB)
+                .withSession(VALID_SESSION_BOB)
                 .withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND).build();
         assertParseSuccess(parser,
                 NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + HEIGHT_DESC_BOB
                 + WEIGHT_DESC_BOB + AGE_DESC_BOB + GENDER_DESC_BOB + DEADLINE_DESC_BOB + PAID_DESC_BOB
-                + BODYFAT_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                + BODYFAT_DESC_BOB + SESSION_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 new AddCommand(expectedPersonMultipleTags));
     }
 
@@ -99,7 +106,7 @@ public class AddCommandParserTest {
     public void parse_repeatedNonTagValue_failure() {
         String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + HEIGHT_DESC_BOB + WEIGHT_DESC_BOB + AGE_DESC_BOB + GENDER_DESC_BOB
-                + DEADLINE_DESC_BOB + PAID_DESC_BOB + BODYFAT_DESC_BOB + TAG_DESC_FRIEND;
+                + DEADLINE_DESC_BOB + PAID_DESC_BOB + BODYFAT_DESC_BOB + SESSION_DESC_BOB + TAG_DESC_FRIEND;
 
         // multiple names
         assertParseFailure(parser, NAME_DESC_AMY + validExpectedPersonString,
@@ -123,7 +130,7 @@ public class AddCommandParserTest {
                         + ADDRESS_DESC_AMY + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_ADDRESS, PREFIX_EMAIL,
                         PREFIX_PHONE, PREFIX_HEIGHT, PREFIX_WEIGHT, PREFIX_AGE, PREFIX_GENDER, PREFIX_DEADLINE,
-                        PREFIX_PAID, PREFIX_BODYFAT));
+                        PREFIX_PAID, PREFIX_SESSION, PREFIX_BODYFAT));
 
         // invalid value followed by valid value
 
@@ -166,10 +173,10 @@ public class AddCommandParserTest {
     public void parse_optionalFieldsMissing_success() {
         // zero tags
         Person expectedPerson = new PersonBuilder(AMY).withGoal("").withPaid("false")
-                .withWeight("60").withBodyfat("18.5").withTags().build();
+                .withWeight("60").withBodyfat("18.5").withSession("WEEKLY:MON 18:00").withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
                 + HEIGHT_DESC_AMY + WEIGHT_DESC_AMY + AGE_DESC_AMY + GENDER_DESC_AMY + DEADLINE_DESC_AMY
-                + PAID_DESC_AMY + BODYFAT_DESC_AMY, new AddCommand(expectedPerson));
+                + PAID_DESC_AMY + BODYFAT_DESC_AMY + SESSION_DESC_AMY, new AddCommand(expectedPerson));
     }
 
     @Test
@@ -226,18 +233,25 @@ public class AddCommandParserTest {
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + HEIGHT_DESC_BOB + WEIGHT_DESC_BOB + AGE_DESC_BOB + GENDER_DESC_BOB + DEADLINE_DESC_BOB
-                + PAID_DESC_BOB + BODYFAT_DESC_BOB + INVALID_TAG_DESC + VALID_TAG_FRIEND,
+                + PAID_DESC_BOB + BODYFAT_DESC_BOB + SESSION_DESC_BOB + INVALID_TAG_DESC + VALID_TAG_FRIEND,
                 Tag.MESSAGE_CONSTRAINTS);
+
+        // invalid session
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + HEIGHT_DESC_BOB + WEIGHT_DESC_BOB + AGE_DESC_BOB + GENDER_DESC_BOB + DEADLINE_DESC_BOB
+                + PAID_DESC_BOB + BODYFAT_DESC_BOB + INVALID_SESSION_DESC + VALID_TAG_FRIEND,
+                Session.MESSAGE_CONSTRAINTS_FORMAT);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
                 + HEIGHT_DESC_BOB + WEIGHT_DESC_BOB + AGE_DESC_BOB + GENDER_DESC_BOB + DEADLINE_DESC_BOB
-                + PAID_DESC_BOB + BODYFAT_DESC_BOB, Name.MESSAGE_CONSTRAINTS);
+                + PAID_DESC_BOB + BODYFAT_DESC_BOB + SESSION_DESC_BOB, Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + HEIGHT_DESC_BOB + WEIGHT_DESC_BOB + AGE_DESC_BOB + GENDER_DESC_BOB
-                + DEADLINE_DESC_BOB + PAID_DESC_BOB + BODYFAT_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                + DEADLINE_DESC_BOB + PAID_DESC_BOB + BODYFAT_DESC_BOB + SESSION_DESC_BOB + TAG_DESC_HUSBAND
+                + TAG_DESC_FRIEND,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -18,6 +18,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Session;
 import seedu.address.model.tag.Tag;
 
 public class ParserUtilTest {
@@ -26,6 +27,7 @@ public class ParserUtilTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_SESSION = "2024-13-40 25:00";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -33,6 +35,7 @@ public class ParserUtilTest {
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
+    private static final String VALID_SESSION = "WEEKLY:MON 18:00";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -192,5 +195,28 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseSession_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseSession((String) null));
+    }
+
+    @Test
+    public void parseSession_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseSession(INVALID_SESSION));
+    }
+
+    @Test
+    public void parseSession_validValueWithoutWhitespace_returnsSession() throws Exception {
+        Session expectedSession = Session.fromString(VALID_SESSION);
+        assertEquals(expectedSession, ParserUtil.parseSession(VALID_SESSION));
+    }
+
+    @Test
+    public void parseSession_validValueWithWhitespace_returnsTrimmedSession() throws Exception {
+        String sessionWithWhitespace = WHITESPACE + VALID_SESSION + WHITESPACE;
+        Session expectedSession = Session.fromString(VALID_SESSION);
+        assertEquals(expectedSession, ParserUtil.parseSession(sessionWithWhitespace));
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -98,6 +98,7 @@ public class PersonTest {
                 + ALICE.getHeight() + ", weight=" + ALICE.getWeight()
                 + ", age=" + ALICE.getAge() + ", gender=" + ALICE.getGender()
                 + ", paid=" + ALICE.getPaymentStatus() + ", bodyfat=" + ALICE.getBodyfat()
+                + ", session=" + ALICE.getSession()
                 + ", tags=" + ALICE.getTags() + "}";
         assertEquals(expected, ALICE.toString());
     }

--- a/src/test/java/seedu/address/model/person/SessionTest.java
+++ b/src/test/java/seedu/address/model/person/SessionTest.java
@@ -1,0 +1,74 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.Test;
+
+public class SessionTest {
+
+    @Test
+    public void fromString_validWeekly_returnsCanonical() {
+        Session session = Session.fromString("weekly:mon 18:00");
+        assertEquals("WEEKLY:MON 18:00", session.toStorageString());
+    }
+
+    @Test
+    public void fromString_validOneOff_returnsCanonical() {
+        String date = LocalDate.now().plusDays(1).format(DateTimeFormatter.ISO_LOCAL_DATE);
+        Session session = Session.fromString(date + " 09:30");
+        assertEquals(date + " 09:30", session.toStorageString());
+    }
+
+    @Test
+    public void fromString_invalidFormat_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, Session.MESSAGE_CONSTRAINTS_FORMAT, () -> Session.fromString("invalid"));
+    }
+
+    @Test
+    public void fromString_invalidTime_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, Session.MESSAGE_CONSTRAINTS_TIME,
+                () -> Session.fromString("WEEKLY:MON 25:00"));
+    }
+
+    @Test
+    public void fromString_invalidDay_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, Session.MESSAGE_CONSTRAINTS_DAY,
+                () -> Session.fromString("WEEKLY:FUNDAY 18:00"));
+    }
+
+    @Test
+    public void fromString_pastDate_throwsIllegalArgumentException() {
+        String pastDate = LocalDate.now().minusDays(1).format(DateTimeFormatter.ISO_LOCAL_DATE);
+        assertThrows(IllegalArgumentException.class, Session.MESSAGE_CONSTRAINTS_PAST_DATE,
+                () -> Session.fromString(pastDate + " 10:00"));
+    }
+
+    @Test
+    public void conflictsWith_sameWeekly_returnsTrue() {
+        Session first = Session.fromString("WEEKLY:MON 18:00");
+        Session second = Session.fromString("weekly:mon 18:00");
+        assertTrue(first.conflictsWith(second));
+    }
+
+    @Test
+    public void conflictsWith_weeklyAndOneOffMatching_returnsTrue() {
+        Session weekly = Session.fromString("WEEKLY:FRI 09:00");
+        String upcomingFriday = LocalDate.now().plusDays((5 - LocalDate.now().getDayOfWeek().getValue() + 7) % 7)
+                .format(DateTimeFormatter.ISO_LOCAL_DATE);
+        Session oneOff = Session.fromString(upcomingFriday + " 09:00");
+        assertTrue(weekly.conflictsWith(oneOff));
+    }
+
+    @Test
+    public void conflictsWith_differentSessions_returnsFalse() {
+        Session weekly = Session.fromString("WEEKLY:MON 09:00");
+        Session otherWeekly = Session.fromString("WEEKLY:TUE 10:00");
+        assertFalse(weekly.conflictsWith(otherWeekly));
+    }
+}

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.person.exceptions.ConflictingSessionException;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.testutil.PersonBuilder;
@@ -56,6 +57,13 @@ public class UniquePersonListTest {
     public void add_duplicatePerson_throwsDuplicatePersonException() {
         uniquePersonList.add(ALICE);
         assertThrows(DuplicatePersonException.class, () -> uniquePersonList.add(ALICE));
+    }
+
+    @Test
+    public void add_conflictingSession_throwsConflictingSessionException() {
+        uniquePersonList.add(ALICE);
+        Person clash = new PersonBuilder(BOB).withSession(ALICE.getSession().toStorageString()).build();
+        assertThrows(ConflictingSessionException.class, () -> uniquePersonList.add(clash));
     }
 
     @Test
@@ -110,6 +118,14 @@ public class UniquePersonListTest {
     }
 
     @Test
+    public void setPerson_conflictingSession_throwsConflictingSessionException() {
+        uniquePersonList.add(ALICE);
+        uniquePersonList.add(BOB);
+        Person editedBob = new PersonBuilder(BOB).withSession(ALICE.getSession().toStorageString()).build();
+        assertThrows(ConflictingSessionException.class, () -> uniquePersonList.setPerson(BOB, editedBob));
+    }
+
+    @Test
     public void remove_nullPerson_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> uniquePersonList.remove(null));
     }
@@ -160,6 +176,13 @@ public class UniquePersonListTest {
     public void setPersons_listWithDuplicatePersons_throwsDuplicatePersonException() {
         List<Person> listWithDuplicatePersons = Arrays.asList(ALICE, ALICE);
         assertThrows(DuplicatePersonException.class, () -> uniquePersonList.setPersons(listWithDuplicatePersons));
+    }
+
+    @Test
+    public void setPersons_listWithConflictingSessions_throwsConflictingSessionException() {
+        Person clash = new PersonBuilder(BOB).withSession(ALICE.getSession().toStorageString()).build();
+        List<Person> listWithConflict = Arrays.asList(ALICE, clash);
+        assertThrows(ConflictingSessionException.class, () -> uniquePersonList.setPersons(listWithConflict));
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -17,6 +17,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Height;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Session;
 import seedu.address.model.person.Weight;
 
 public class JsonAdaptedPersonTest {
@@ -32,6 +33,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_AGE = "150"; // invalid age
     private static final String INVALID_GENDER = "invalid"; // invalid gender
     private static final String INVALID_PAID = "notaboolean";
+    private static final String INVALID_SESSION = "WEEKLY:FUNDAY 18:00";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
@@ -45,6 +47,7 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_GENDER = BENSON.getGender().toString();
     private static final String VALID_PAID = BENSON.getPaymentStatus().toString();
     private static final String VALID_BODYFAT = BENSON.getBodyfat().toString();
+    private static final String VALID_SESSION = BENSON.getSession().toStorageString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -60,7 +63,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_GOAL,
                         VALID_HEIGHT, VALID_WEIGHT, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
-                        VALID_PAID, VALID_BODYFAT, VALID_TAGS);
+                        VALID_PAID, VALID_SESSION, VALID_BODYFAT, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -69,7 +72,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                 VALID_GOAL, VALID_HEIGHT, VALID_WEIGHT, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
-                VALID_PAID, VALID_BODYFAT, VALID_TAGS);
+                VALID_PAID, VALID_SESSION, VALID_BODYFAT, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -79,7 +82,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                         VALID_GOAL, VALID_HEIGHT, VALID_WEIGHT, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
-                        VALID_PAID, VALID_BODYFAT, VALID_TAGS);
+                        VALID_PAID, VALID_SESSION, VALID_BODYFAT, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -88,7 +91,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
                 VALID_GOAL, VALID_HEIGHT, VALID_WEIGHT, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
-                VALID_PAID, VALID_BODYFAT, VALID_TAGS);
+                VALID_PAID, VALID_SESSION, VALID_BODYFAT, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -98,7 +101,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
                         VALID_GOAL, VALID_HEIGHT, VALID_WEIGHT, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
-                        VALID_PAID, VALID_BODYFAT, VALID_TAGS);
+                        VALID_PAID, VALID_SESSION, VALID_BODYFAT, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -107,7 +110,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
                 VALID_GOAL, VALID_HEIGHT, VALID_WEIGHT, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
-                VALID_PAID, VALID_BODYFAT, VALID_TAGS);
+                VALID_PAID, VALID_SESSION, VALID_BODYFAT, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -117,8 +120,26 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
                         VALID_GOAL, VALID_HEIGHT, VALID_WEIGHT, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
-                        VALID_PAID, VALID_BODYFAT, VALID_TAGS);
+                        VALID_PAID, VALID_SESSION, VALID_BODYFAT, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidSession_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_GOAL,
+                        VALID_HEIGHT, VALID_WEIGHT, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
+                        VALID_PAID, INVALID_SESSION, VALID_BODYFAT, VALID_TAGS);
+        assertThrows(IllegalValueException.class, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullSession_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_GOAL, VALID_HEIGHT, VALID_WEIGHT, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
+                VALID_PAID, null, VALID_BODYFAT, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Session.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
@@ -128,7 +149,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_GOAL,
                         INVALID_HEIGHT, VALID_WEIGHT, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
-                        VALID_PAID, VALID_BODYFAT, VALID_TAGS);
+                        VALID_PAID, VALID_SESSION, VALID_BODYFAT, VALID_TAGS);
         String expectedMessage = Height.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -138,7 +159,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_GOAL,
                         null, VALID_WEIGHT, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
-                        VALID_PAID, VALID_BODYFAT, VALID_TAGS);
+                        VALID_PAID, VALID_SESSION, VALID_BODYFAT, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Height.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -147,7 +168,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
                 VALID_GOAL, VALID_HEIGHT, VALID_WEIGHT, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
-                VALID_PAID, VALID_BODYFAT, VALID_TAGS);
+                VALID_PAID, VALID_SESSION, VALID_BODYFAT, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -158,8 +179,8 @@ public class JsonAdaptedPersonTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_GOAL, VALID_WEIGHT, VALID_HEIGHT, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
-                        VALID_PAID, VALID_BODYFAT, invalidTags);
+                        VALID_GOAL, VALID_HEIGHT, VALID_WEIGHT, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
+                        VALID_PAID, VALID_SESSION, VALID_BODYFAT, invalidTags);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
@@ -168,7 +189,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
                 VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_GOAL,
                 VALID_HEIGHT, INVALID_WEIGHT, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
-                VALID_PAID, VALID_BODYFAT, VALID_TAGS);
+                VALID_PAID, VALID_SESSION, VALID_BODYFAT, VALID_TAGS);
         String expectedMessage = Weight.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -178,10 +199,8 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
                 VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_GOAL,
                 VALID_HEIGHT, null, VALID_AGE, VALID_GENDER, VALID_DEADLINE,
-                VALID_PAID, VALID_BODYFAT, VALID_TAGS);
+                VALID_PAID, VALID_SESSION, VALID_BODYFAT, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Weight.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
-
-
 }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -17,6 +17,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Paid;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Session;
 import seedu.address.model.person.Weight;
 import seedu.address.model.tag.Tag;
 
@@ -51,6 +52,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setDeadline(person.getDeadline());
         descriptor.setPaid(person.getPaymentStatus());
         descriptor.setBodyfat(person.getBodyfat());
+        descriptor.setSession(person.getSession());
         descriptor.setTags(person.getTags());
     }
 
@@ -147,6 +149,14 @@ public class EditPersonDescriptorBuilder {
      */
     public EditPersonDescriptorBuilder withBodyfat(String bodyfat) {
         descriptor.setBodyfat(new Bodyfat(bodyfat));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Session} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withSession(String session) {
+        descriptor.setSession(Session.fromString(session));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -15,6 +15,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Paid;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Session;
 import seedu.address.model.person.Weight;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
@@ -36,6 +37,7 @@ public class PersonBuilder {
     public static final String DEFAULT_DEADLINE = "2025-12-31";
     public static final String DEFAULT_PAID = "true";
     public static final String DEFAULT_BODYFAT = "30.0";
+    public static final String DEFAULT_SESSION = "WEEKLY:MON 18:00";
 
     private Name name;
     private Phone phone;
@@ -49,6 +51,7 @@ public class PersonBuilder {
     private Deadline deadline;
     private Paid paid;
     private Bodyfat bodyfat;
+    private Session session;
     private Set<Tag> tags;
 
     /**
@@ -67,6 +70,7 @@ public class PersonBuilder {
         deadline = Deadline.fromString(DEFAULT_DEADLINE);
         paid = new Paid(DEFAULT_PAID);
         bodyfat = new Bodyfat(DEFAULT_BODYFAT);
+        session = Session.fromString(DEFAULT_SESSION);
         tags = new HashSet<>();
     }
 
@@ -86,6 +90,7 @@ public class PersonBuilder {
         deadline = personToCopy.getDeadline();
         paid = personToCopy.getPaymentStatus();
         bodyfat = personToCopy.getBodyfat();
+        session = personToCopy.getSession();
         tags = new HashSet<>(personToCopy.getTags());
     }
 
@@ -194,13 +199,21 @@ public class PersonBuilder {
     }
 
     /**
+     * Sets the {@code Session} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withSession(String session) {
+        this.session = Session.fromString(session);
+        return this;
+    }
+
+    /**
      * Builds the person with the specified attributes.
      *
      * @return the built person
      */
     public Person build() {
         return new Person(name, phone, email, address, goal, height, weight, age, gender,
-                deadline, paid, bodyfat, tags);
+                deadline, paid, bodyfat, session, tags);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_HEIGHT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PAID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SESSION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_WEIGHT;
 
@@ -48,6 +49,7 @@ public class PersonUtil {
         sb.append(PREFIX_DEADLINE + person.getDeadline().toStorageString() + " ");
         sb.append(PREFIX_PAID + person.getPaymentStatus().toString() + " ");
         sb.append(PREFIX_BODYFAT + String.valueOf(person.getBodyfat().value) + " ");
+        sb.append(PREFIX_SESSION + person.getSession().toStorageString() + " ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );
@@ -71,6 +73,8 @@ public class PersonUtil {
                 .append(deadline.toStorageString()).append(" "));
         descriptor.getPaid().ifPresent(paid -> sb.append(PREFIX_PAID).append(paid.toString()).append(" "));
         descriptor.getBodyfat().ifPresent(bodyfat -> sb.append(PREFIX_BODYFAT).append(bodyfat.value).append(" "));
+        descriptor.getSession().ifPresent(session -> sb.append(PREFIX_SESSION).append(session.toStorageString())
+                .append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -10,6 +10,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SESSION_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SESSION_BOB;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,49 +29,51 @@ public class TypicalPersons {
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253").withGoal("Lose 5kg")
             .withHeight("165").withWeight("60").withAge("25").withGender("female").withDeadline("2025-12-31")
-            .withPaid("true").withBodyfat("18.5").withTags("friends").build();
+            .withPaid("true").withBodyfat("18.5").withSession("WEEKLY:MON 08:00").withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432").withGoal("Lose 5kg")
             .withHeight("175").withWeight("75").withAge("30").withGender("male").withDeadline("2025-12-31")
-            .withPaid("true").withBodyfat("20.0").withTags("owesMoney", "friends").build();
+            .withPaid("true").withBodyfat("20.0").withSession("WEEKLY:TUE 09:00")
+            .withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street")
             .withHeight("180").withWeight("80").withAge("28").withGender("male").withDeadline("2025-12-31")
-            .withPaid("true").withBodyfat("22.0").build();
+            .withPaid("true").withBodyfat("22.0").withSession("WEEKLY:WED 10:00").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street")
             .withHeight("170").withWeight("70").withAge("32").withGender("male").withDeadline("2025-12-31")
-            .withPaid("true").withBodyfat("19.5").withTags("friends").build();
+            .withPaid("true").withBodyfat("19.5").withSession("WEEKLY:THU 11:00").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("werner@example.com").withAddress("michegan ave")
             .withHeight("160").withWeight("55").withAge("26").withGender("female").withDeadline("2025-12-31")
-            .withPaid("true").withBodyfat("17.5").build();
+            .withPaid("true").withBodyfat("17.5").withSession("WEEKLY:FRI 12:00").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("lydia@example.com").withAddress("little tokyo")
             .withHeight("155").withWeight("50").withAge("24").withGender("female").withDeadline("2025-12-31")
-            .withPaid("true").withBodyfat("16.0").build();
+            .withPaid("true").withBodyfat("16.0").withSession("WEEKLY:SAT 13:00").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
             .withEmail("anna@example.com").withAddress("4th street")
             .withHeight("185").withWeight("85").withAge("35").withGender("male").withDeadline("2025-12-31")
-            .withPaid("true").withBodyfat("21.0").build();
+            .withPaid("true").withBodyfat("21.0").withSession("WEEKLY:SUN 14:00").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
             .withEmail("stefan@example.com").withAddress("little india")
-            .withHeight("175").withAge("29").withGender("male").build();
+            .withHeight("175").withAge("29").withGender("male").withSession("BIWEEKLY:MON 18:00").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
             .withEmail("hans@example.com").withAddress("chicago ave")
-            .withHeight("165").withAge("27").withGender("female").build();
+            .withHeight("165").withAge("27").withGender("female").withSession("BIWEEKLY:TUE 18:30").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
             .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-            .withHeight("160").withAge("25").withGender("female").withTags(VALID_TAG_FRIEND).build();
+            .withHeight("160").withAge("25").withGender("female").withSession(VALID_SESSION_AMY)
+            .withTags(VALID_TAG_FRIEND).build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
             .withHeight("175").withAge("30").withGender("male")
-            .withGoal("Lose 5kg").withPaid("true")
+            .withGoal("Lose 5kg").withPaid("true").withSession(VALID_SESSION_BOB)
             .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
             .build();
 


### PR DESCRIPTION
## Summary
- add a Session value object that validates schedule strings and checks for conflicts
- require and parse session data for persons across commands, storage, and UI
- prevent conflicting bookings when adding or editing people and extend tests accordingly

## Testing
- ./gradlew test *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68f4c6e1ca78833385e37428b8280b4b